### PR TITLE
feat: Remove tokio support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,6 @@ jobs:
       run: rustup update ${{ matrix.rust }} --no-self-update && rustup default ${{ matrix.rust }}
       shell: bash
     - run: cargo test
-    - run: cargo test --features tokio
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,17 +19,13 @@ categories = ["compression", "api-bindings"]
 [dependencies]
 libc = "0.2"
 bzip2-sys = { version = "0.1.11", path = "bzip2-sys" }
-tokio-io = { version = "0.1", optional = true }
-futures = { version = "0.1", optional = true }
 
 [dev-dependencies]
 rand = "0.8"
 partial-io = { version = "0.3", features = ["quickcheck"] }
 quickcheck = "1.0"
 quickcheck6 = { version = "0.6", package = "quickcheck" }
-tokio-core = "0.1"
 
 [features]
-tokio = ["tokio-io", "futures"]
 # Enable this feature if you want to have a statically linked bzip2
 static = ["bzip2-sys/static"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,15 +40,6 @@
 //! incomplete and exactly 900K bytes, you probably need a
 //! `MultiBzDecoder`.
 //!
-//! # Async I/O
-//!
-//! This crate optionally can support async I/O streams with the Tokio stack via
-//! the `tokio` feature of this crate:
-//!
-//! ```toml
-//! bzip2 = { version = "0.4", features = ["tokio"] }
-//! ```
-//!
 //! All methods are internally capable of working with streams that may return
 //! `ErrorKind::WouldBlock` when they're not ready to perform the particular
 //! operation.
@@ -71,11 +62,6 @@ extern crate partial_io;
 extern crate quickcheck;
 #[cfg(test)]
 extern crate rand;
-#[cfg(feature = "tokio")]
-#[macro_use]
-extern crate tokio_io;
-#[cfg(feature = "tokio")]
-extern crate futures;
 
 pub use mem::{Action, Compress, Decompress, Error, Status};
 

--- a/src/read.rs
+++ b/src/read.rs
@@ -3,11 +3,6 @@
 use std::io::prelude::*;
 use std::io::{self, BufReader};
 
-#[cfg(feature = "tokio")]
-use futures::Poll;
-#[cfg(feature = "tokio")]
-use tokio_io::{AsyncRead, AsyncWrite};
-
 use bufread;
 use Compression;
 
@@ -76,9 +71,6 @@ impl<R: Read> Read for BzEncoder<R> {
     }
 }
 
-#[cfg(feature = "tokio")]
-impl<R: AsyncRead> AsyncRead for BzEncoder<R> {}
-
 impl<W: Write + Read> Write for BzEncoder<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.get_mut().write(buf)
@@ -86,13 +78,6 @@ impl<W: Write + Read> Write for BzEncoder<W> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.get_mut().flush()
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<R: AsyncWrite + Read> AsyncWrite for BzEncoder<R> {
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        self.get_mut().shutdown()
     }
 }
 
@@ -147,9 +132,6 @@ impl<R: Read> Read for BzDecoder<R> {
     }
 }
 
-#[cfg(feature = "tokio")]
-impl<R: AsyncRead + Read> AsyncRead for BzDecoder<R> {}
-
 impl<W: Write + Read> Write for BzDecoder<W> {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         self.get_mut().write(buf)
@@ -157,13 +139,6 @@ impl<W: Write + Read> Write for BzDecoder<W> {
 
     fn flush(&mut self) -> io::Result<()> {
         self.get_mut().flush()
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<R: AsyncWrite + Read> AsyncWrite for BzDecoder<R> {
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        self.get_mut().shutdown()
     }
 }
 
@@ -208,26 +183,6 @@ impl<R> MultiBzDecoder<R> {
 impl<R: Read> Read for MultiBzDecoder<R> {
     fn read(&mut self, into: &mut [u8]) -> io::Result<usize> {
         self.inner.read(into)
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<R: AsyncRead> AsyncRead for MultiBzDecoder<R> {}
-
-impl<R: Read + Write> Write for MultiBzDecoder<R> {
-    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
-        self.get_mut().write(buf)
-    }
-
-    fn flush(&mut self) -> io::Result<()> {
-        self.get_mut().flush()
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<R: AsyncWrite + AsyncRead> AsyncWrite for MultiBzDecoder<R> {
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        self.get_mut().shutdown()
     }
 }
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -3,11 +3,6 @@
 use std::io;
 use std::io::prelude::*;
 
-#[cfg(feature = "tokio")]
-use futures::Poll;
-#[cfg(feature = "tokio")]
-use tokio_io::{AsyncRead, AsyncWrite};
-
 use {Action, Compress, Compression, Decompress, Status};
 
 /// A compression stream which will have uncompressed data written to it and
@@ -151,31 +146,6 @@ impl<W: Write> Write for BzEncoder<W> {
     }
 }
 
-#[cfg(feature = "tokio")]
-impl<W: AsyncWrite> AsyncWrite for BzEncoder<W> {
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        try_nb!(self.try_finish());
-        self.get_mut().shutdown()
-    }
-}
-
-impl<W: Read + Write> Read for BzEncoder<W> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.get_mut().read(buf)
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<W: AsyncRead + AsyncWrite> AsyncRead for BzEncoder<W> {}
-
-impl<W: Write> Drop for BzEncoder<W> {
-    fn drop(&mut self) {
-        if self.obj.is_some() {
-            let _ = self.try_finish();
-        }
-    }
-}
-
 impl<W: Write> BzDecoder<W> {
     /// Create a new decoding stream which will decompress all data written
     /// to it into `obj`.
@@ -286,23 +256,6 @@ impl<W: Write> Write for BzDecoder<W> {
         self.obj.as_mut().unwrap().flush()
     }
 }
-
-#[cfg(feature = "tokio")]
-impl<W: AsyncWrite> AsyncWrite for BzDecoder<W> {
-    fn shutdown(&mut self) -> Poll<(), io::Error> {
-        try_nb!(self.try_finish());
-        self.get_mut().shutdown()
-    }
-}
-
-impl<W: Read + Write> Read for BzDecoder<W> {
-    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
-        self.get_mut().read(buf)
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<W: AsyncRead + AsyncWrite> AsyncRead for BzDecoder<W> {}
 
 impl<W: Write> Drop for BzDecoder<W> {
     fn drop(&mut self) {


### PR DESCRIPTION
Similar to https://github.com/rust-lang/flate2-rs/pull/292 and https://github.com/alexcrichton/xz2-rs/pull/109, this removes outdated tokio 0.1 support.