### PR TITLE
Avoid infinite loop writing and empty buffer (in write::BzDecoder)

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -311,6 +311,13 @@ mod tests {
     }
 
     #[test]
+    fn write_empty2() {
+        let mut d = BzDecoder::new(Vec::new());
+        d.write(b"").unwrap();
+        d.finish().unwrap();
+    }
+
+    #[test]
     fn qc() {
         ::quickcheck::quickcheck(test as fn(_) -> _);
 

--- a/src/write.rs
+++ b/src/write.rs
@@ -203,7 +203,8 @@ impl<W: Write> BzDecoder<W> {
     ///
     /// [`write`]: Self::write
     pub fn try_finish(&mut self) -> io::Result<()> {
-        while !self.done {
+        // If nothing was written, there is no need to loop
+        while !self.done && self.total_in() > 0 {
             let _ = self.write(&[])?;
         }
         self.dump()


### PR DESCRIPTION
In `write::BzDecoder::try_finish` do not loop if nothing was written

Closes #96