### PR TITLE
Update LICENSE-MIT

### DIFF
--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,4 +1,4 @@
-Copyright (c) 2014 Alex Crichton
+Copyright (c) 2014-2024 Alex Crichton and Contributors
 
 Permission is hereby granted, free of charge, to any
 person obtaining a copy of this software and associated


### PR DESCRIPTION
Update copyright line for clarity:
- Alex has been making modifications since 2014
- presumably no (c)-transfer has been arranged so copyright also belongs to the other contributors to this repo.
- Trifecta has also made some modifications, but these are relatively small and so I see no need to add a separate "Copyright (c) 2024 Trifecta Tech Foundation" line right now.