### PR TITLE
write::BzDecoder: Fix infinite loop on drop when no data is read or written

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -204,7 +204,15 @@ impl<W: Write> BzDecoder<W> {
     /// [`write`]: Self::write
     pub fn try_finish(&mut self) -> io::Result<()> {
         while !self.done {
-            let _ = self.write(&[])?;
+            let before = self.total_in();
+            let written = self.write(&[])?;
+
+            if self.total_in() == before && written == 0 {
+                return Err(io::Error::new(
+                    io::ErrorKind::UnexpectedEof,
+                    "Input EOF reached before logical stream ends",
+                ));
+            }
         }
         self.dump()
     }


### PR DESCRIPTION
If writes to the `BzDecoder` end before it has been fed the entire stream and the output buffer has already been flushed to the wrapped writer, then the `Drop` implementation will loop forever. On drop, `try_finish()` is called, which repeatedly tries to `write()` until `BZ_STREAM_END` is returned or an error occurs, but neither scenario happens if there's no input nor output data to process.

This commit makes `try_finish()` return an `UnexpectedEof` error in this scenario.

---

(Also, really happy to see this library found a new maintainer!)