### PR TITLE
Add finisher drop implementation to BzEncoder

### DIFF
--- a/src/write.rs
+++ b/src/write.rs
@@ -287,6 +287,14 @@ impl<W: Write> Drop for BzDecoder<W> {
     }
 }
 
+impl<W: Write> Drop for BzEncoder<W> {
+    fn drop(&mut self) {
+        if self.obj.is_some() {
+            let _ = self.try_finish();
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::{BzDecoder, BzEncoder};

--- a/src/write.rs
+++ b/src/write.rs
@@ -394,8 +394,11 @@ mod tests {
 
     #[test]
     fn terminate_on_drop() {
-        // Test that dropping the BzEncoder will result in a valid, decompressable datastream
-        let s = "12345".repeat(100000);
+        // Test that dropping the BzEncoder flushes bytes to the output, so that
+        // we get a valid, decompressable datastream
+        //
+        // see https://github.com/trifectatechfoundation/bzip2-rs/pull/121
+        let s = "12345".repeat(100);
 
         let mut compressed = Vec::new();
         {
@@ -413,7 +416,7 @@ mod tests {
             d.finish().unwrap()
         };
         assert_eq!(&uncompressed[0..5], b"12834");
-        assert_eq!(uncompressed.len(), 500005);
+        assert_eq!(uncompressed.len(), s.len() + "12834".len());
         assert!(format!("12834{}", s).as_bytes() == &*uncompressed);
     }
 }


### PR DESCRIPTION
This ensures that finish will always be attempted to be called, for
example when operating as a `Box<dyn Writer>`. This existed in the 0.4 version of the crate and adding back the implementation fixes some test failures I observed after upgrading.

Without the `Drop` implementation the generated byte sequence ends up too short and cannot be decompressed.