### PR TITLE
don't enable the `static` feature when using `libbz2-rs-sys`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,10 @@ quickcheck = "1.0"
 
 [features]
 default = ["dep:bzip2-sys"]
-# Use `libbz2-rs-sys` instead of the C FFI bindings of `bzip2-sys`
-# Using the rust implementation is always static
-libbz2-rs-sys = ["dep:libbz2-rs-sys", "static"]
-# Enable this feature if you want to have a statically linked bzip2
+# Use the pure rust `libbz2-rs-sys` instead of the C FFI bindings of `bzip2-sys`
+# The rust bzip2 implementation is always statically linked.
+libbz2-rs-sys = ["dep:libbz2-rs-sys"]
+# Always build `libbz2` from C source, and statically link it.
+# This flag is only meaningful when `bzip2-sys` is used,
+# and has no effect when `libbz2-rs-sys` is used as the bzip2 implementation.
 static = ["bzip2-sys?/static"]

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ bzip2 = { version = "0.5.0", default-features = false, features = ["libbz2-rs-sy
 
 *`static`*
 
-Always build `libbz2` from source, and statically link it. When `libbz2-rs-sys` is enabled, static mode is always used.
+Always build `libbz2` from C source, and statically link it. This flag is only meaningful when `bzip2-sys` is used,
+and has no effect when `libbz2-rs-sys` is used as the bzip2 implementation.
 
 ## License
 


### PR DESCRIPTION
fixes https://github.com/trifectatechfoundation/bzip2-rs/issues/120