### PR TITLE
update libbz2-rs-sys version that we use

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 bzip2-sys = { version = "0.1.11", path = "bzip2-sys", optional = true }
 
 [dependencies.libbz2-rs-sys]
-version = "0.1.0"
+version = "0.1.1"
 # Don't enable the stdio feature for better portability.
 default-features = false
 features = ["rust-allocator"]


### PR DESCRIPTION
the older version causes errors 

```
error[E0433]: failed to resolve: use of undeclared crate or module `std`
   --> /home/folkertdev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libbz2-rs-sys-0.1.0/src/allocator.rs:151:36
    |
151 |                 let ptr = unsafe { std::alloc::alloc_zeroed(layout) };
    |                                    ^^^ use of undeclared crate or module `std`

error[E0433]: failed to resolve: use of undeclared crate or module `std`
   --> /home/folkertdev/.cargo/registry/src/index.crates.io-6f17d22bba15001f/libbz2-rs-sys-0.1.0/src/allocator.rs:185:26
    |
185 |                 unsafe { std::alloc::dealloc(ptr.cast(), layout) }
    |                          ^^^ use of undeclared crate or module `std`
```