### PR TITLE
Disable bzip2-sys build script if rust backend is enabled

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ quickcheck = "1.0"
 default = ["dep:bzip2-sys"]
 # Use the pure rust `libbz2-rs-sys` instead of the C FFI bindings of `bzip2-sys`
 # The rust bzip2 implementation is always statically linked.
-libbz2-rs-sys = ["dep:libbz2-rs-sys"]
+libbz2-rs-sys = ["dep:libbz2-rs-sys", "bzip2-sys?/__disabled"]
 # Always build `libbz2` from C source, and statically link it.
 # This flag is only meaningful when `bzip2-sys` is used,
 # and has no effect when `libbz2-rs-sys` is used as the bzip2 implementation.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 bzip2-sys = { version = "0.1.11", path = "bzip2-sys", optional = true }
 
 [dependencies.libbz2-rs-sys]
-version = "0.1.2"
+version = "0.1.3"
 # Don't enable the stdio feature for better portability.
 default-features = false
 features = ["rust-allocator", "semver-prefix"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ libc = "0.2"
 bzip2-sys = { version = "0.1.11", path = "bzip2-sys", optional = true }
 
 [dependencies.libbz2-rs-sys]
-version = "0.1.1"
+version = "0.1.2"
 # Don't enable the stdio feature for better portability.
 default-features = false
-features = ["rust-allocator"]
+features = ["rust-allocator", "semver-prefix"]
 optional = true
 
 [dev-dependencies]

--- a/bzip2-sys/Cargo.toml
+++ b/bzip2-sys/Cargo.toml
@@ -28,3 +28,4 @@ cc = "1.0"
 [features]
 # Enable this feature if you want to have a statically linked bzip2
 static = []
+__disabled = []

--- a/bzip2-sys/build.rs
+++ b/bzip2-sys/build.rs
@@ -4,6 +4,7 @@ extern crate pkg_config;
 use std::path::PathBuf;
 use std::{env, fs};
 
+#[cfg(not(feature = "__disabled"))]
 fn main() {
     let mut cfg = cc::Build::new();
     let target = env::var("TARGET").unwrap();
@@ -45,3 +46,6 @@ fn main() {
     println!("cargo:root={}", dst.display());
     println!("cargo:include={}", dst.join("include").display());
 }
+
+#[cfg(feature = "__disabled")]
+fn main() {}

--- a/bzip2-sys/build.rs
+++ b/bzip2-sys/build.rs
@@ -4,8 +4,12 @@ extern crate pkg_config;
 use std::path::PathBuf;
 use std::{env, fs};
 
-#[cfg(not(feature = "__disabled"))]
 fn main() {
+    // skip building the C library when libbzip2-rs is also used
+    if cfg!(feature = "__disabled") {
+        return;
+    }
+
     let mut cfg = cc::Build::new();
     let target = env::var("TARGET").unwrap();
     cfg.warnings(false);
@@ -46,6 +50,3 @@ fn main() {
     println!("cargo:root={}", dst.display());
     println!("cargo:include={}", dst.join("include").display());
 }
-
-#[cfg(feature = "__disabled")]
-fn main() {}


### PR DESCRIPTION
Currently if one is to enable rust backend without disabling default features, the bzip2-sys build script would build the bzip2 again, making it meaningless to enable the feature.

In many cases disabling default-features is hard (breaking backwards compatibility), so it'd be better to disable the bzip2-sys bulid-script, if the rust backend is enabled'

It would still pull in cc-rs and pkg-config, but at least it won't compile the bzip2 c code again.'