### PR TITLE
use `core::ffi::{c_int, c_uint}` in favor of `libc`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ publish = true
 [workspace]
 
 [dependencies]
-libc = "0.2"
 bzip2-sys = { version = "0.1.11", path = "bzip2-sys", optional = true }
 
 [dependencies.libbz2-rs-sys]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,6 @@
 extern crate bzip2_sys as ffi;
 #[cfg(feature = "libbz2-rs-sys")]
 extern crate libbz2_rs_sys as ffi;
-extern crate libc;
 #[cfg(test)]
 extern crate partial_io;
 #[cfg(test)]

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -6,7 +6,7 @@ use std::marker;
 use std::mem;
 use std::slice;
 
-use libc::{c_int, c_uint};
+use core::ffi::{c_int, c_uint};
 
 use crate::{ffi, Compression};
 


### PR DESCRIPTION
libc does not expose those types for some targets (notable wasm32-unknown-unknown).

Turns out that the main crate only needed libc for these types, so the whole dependency can go here (but of course libc is still used by either `bzip2-sys` or `libbz2-rs-sys`.