### PR TITLE
fix: libc wasm types

### DIFF
--- a/bzip2-sys/lib.rs
+++ b/bzip2-sys/lib.rs
@@ -2,7 +2,7 @@
 
 extern crate libc;
 
-use libc::{c_char, c_int, c_uint, c_void};
+use std::ffi::{c_char, c_int, c_uint, c_void};
 
 pub const BZ_RUN: c_int = 0;
 pub const BZ_FLUSH: c_int = 1;


### PR DESCRIPTION
Some of the libc types are not available on WASM. Use the std types instead.