### PR TITLE
remove libc dependency of `bzip2-sys`

### DIFF
--- a/bzip2-sys/Cargo.toml
+++ b/bzip2-sys/Cargo.toml
@@ -19,7 +19,6 @@ name = "bzip2_sys"
 path = "lib.rs"
 
 [dependencies]
-libc = "0.2"
 
 [build-dependencies]
 pkg-config = "0.3.9"

--- a/bzip2-sys/lib.rs
+++ b/bzip2-sys/lib.rs
@@ -1,8 +1,7 @@
 #![doc(html_root_url = "https://docs.rs/bzip2-sys/0.1")]
+#![no_std]
 
-extern crate libc;
-
-use std::ffi::{c_char, c_int, c_uint, c_void};
+use core::ffi::{c_char, c_int, c_uint, c_void};
 
 pub const BZ_RUN: c_int = 0;
 pub const BZ_FLUSH: c_int = 1;


### PR DESCRIPTION
it's no longer used. In the sys crate I'd also like to use `core`, but apparently that is not possible with edition 2015.