### PR TITLE
Release 0.6.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,28 +63,27 @@ jobs:
         rustup target add wasm32-wasip2
       shell: bash
       if: matrix.build == 'wasm32'
-    - name: Run cargo doc, deny warnings (bzip2-sys)
+    - name: Run cargo doc, deny warnings (libbzip2-rs-sys)
       env:
         RUSTDOCFLAGS: "-D warnings"
       run: |
-        cargo doc -p bzip2-sys --no-deps
         cargo doc -p bzip2 --no-deps
-    - name: Run cargo doc, deny warnings (libbz2-rs-sys)
+    - name: Run cargo doc, deny warnings (bzip2-sys)
       env:
           RUSTDOCFLAGS: "-Dwarnings"
-      if: matrix.build != 'msrv'
-      run: cargo doc -p bzip2 --no-deps --no-default-features --features libbz2-rs-sys
+      run: |
+        cargo doc -p bzip2-sys --no-deps
+        cargo doc -p bzip2 --no-deps --no-default-features --features bzip2-sys
     - name: Configure wasm32 env vars
       run: |
         echo "CARGO_TARGET_WASM32_WASIP2_RUNNER=/home/runner/.wasmtime/bin/wasmtime" >> $GITHUB_ENV
         echo "CARGO_BUILD_TARGET=wasm32-wasip2" >> $GITHUB_ENV
       if: matrix.build == 'wasm32'
-    - name: Run cargo test (bzip2-sys)
-      run: cargo test
-      if: matrix.build != 'wasm32'
     - name: Run cargo test (libbzip2-rs-sys)
-      run: cargo test --no-default-features --features libbz2-rs-sys
-      if: matrix.build != 'msrv'
+      run: cargo test
+    - name: Run cargo test (bzip2-sys)
+      run: cargo test --no-default-features --features bzip2-sys
+      if: matrix.build != 'wasm32'
 
   rustfmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 edition = "2021"
 name = "bzip2"
-version = "0.5.2"
+version = "0.6.0"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 keywords = ["bzip", "encoding"]
@@ -13,7 +13,7 @@ Bindings to libbzip2 for bzip2 compression and decompression exposed as
 Reader/Writer streams.
 """
 categories = ["compression", "api-bindings"]
-rust-version = "1.65.0" # MSRV
+rust-version = "1.82.0" # MSRV
 publish = true
 
 [workspace]
@@ -22,10 +22,10 @@ publish = true
 bzip2-sys = { version = "0.1.13", path = "bzip2-sys", optional = true }
 
 [dependencies.libbz2-rs-sys]
-version = "0.1.3"
+version = "0.2.1"
 # Don't enable the stdio feature for better portability.
 default-features = false
-features = ["rust-allocator", "semver-prefix"]
+features = ["rust-allocator"]
 optional = true
 
 [dev-dependencies]
@@ -34,11 +34,9 @@ partial-io = { version = "0.5.4", features = ["quickcheck1"] }
 quickcheck = "1.0"
 
 [features]
-default = ["dep:bzip2-sys"]
-# Use the pure rust `libbz2-rs-sys` instead of the C FFI bindings of `bzip2-sys`
-# The rust bzip2 implementation is always statically linked.
-libbz2-rs-sys = ["dep:libbz2-rs-sys", "bzip2-sys?/__disabled"]
+default = ["dep:libbz2-rs-sys"] 
+# Use the C bzip2 implementation. This will try to find the bzip2 dynamic library on your system, or build it from source. 
+bzip2-sys = ["dep:bzip2-sys"]
 # Always build `libbz2` from C source, and statically link it.
 # This flag is only meaningful when `bzip2-sys` is used,
-# and has no effect when `libbz2-rs-sys` is used as the bzip2 implementation.
 static = ["bzip2-sys?/static"]

--- a/bzip2-sys/lib.rs
+++ b/bzip2-sys/lib.rs
@@ -48,7 +48,7 @@ macro_rules! abi_compat {
             $(pub fn $name($($arg: $t),*) -> $ret;)*
         }
         #[cfg(not(windows))]
-        extern {
+        extern "C" {
             $(pub fn $name($($arg: $t),*) -> $ret;)*
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -56,9 +56,9 @@
 #![deny(missing_docs)]
 #![doc(html_root_url = "https://docs.rs/bzip2/")]
 
-#[cfg(not(feature = "libbz2-rs-sys"))]
+#[cfg(feature = "bzip2-sys")]
 extern crate bzip2_sys as ffi;
-#[cfg(feature = "libbz2-rs-sys")]
+#[cfg(not(feature = "bzip2-sys"))]
 extern crate libbz2_rs_sys as ffi;
 #[cfg(test)]
 extern crate partial_io;

--- a/src/mem.rs
+++ b/src/mem.rs
@@ -305,7 +305,7 @@ impl fmt::Display for Error {
 
 impl From<Error> for std::io::Error {
     fn from(data: Error) -> std::io::Error {
-        std::io::Error::new(std::io::ErrorKind::Other, data)
+        std::io::Error::other(data)
     }
 }
 


### PR DESCRIPTION
This release makes `libbz2-rs-sys` the default, solving a lot of cross-compilation and linking issues in one fell swoop.